### PR TITLE
Add https check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { fetchStats } from './lib/check.js'
 import { output } from './lib/output.js'
 import { debug } from './lib/debug.js'
 import { rank } from './lib/grade.js'
+import { httpsCheck } from './lib/https-check.js'
 
 export async function main () {
   const knownConfigUrls = {
@@ -38,6 +39,7 @@ export async function main () {
 
     // Fetch the same data from all nodes and process it
     Promise.all(config.API.GraphQL.Hosts.map(fetchStats))
+      .then(httpsCheck)
       .then(rank)
       .then(debug)
       .then(output)

--- a/src/lib/check.js
+++ b/src/lib/check.js
@@ -1,4 +1,5 @@
 import { listHash, stakeHash, paramHash, prepareForHash, sortLists } from './hash.js'
+import { looksLikeHTTPS } from './https-check.js'
 
 // Statistics to pull from the `statistics` property of the result and put on each node
 const statsWeCareAbout = ['blockHeight', 'totalPeers']
@@ -18,7 +19,7 @@ const query = `{
     edges {
       node {
         name
-        stakedTotal        
+        stakedTotal
       }
     }
   }
@@ -87,7 +88,7 @@ const query = `{
           edges {
             node {
               type
-              balance              
+              balance
             }
           }
         }
@@ -170,6 +171,7 @@ function fakeCheck (url, error) {
     paramHash: '-',
     steakHash: '-',
     hashHash: '-',
+    https: false,
     data: {
       error
     }
@@ -201,7 +203,8 @@ export function check (urlFromConfig, stats) {
       vegaTime: stats.data.statistics.vegaTime,
       chainId: stats.data.statistics.chainId,
       epoch: stats.data.epoch.id,
-      timestamps: stats.data.epoch.timestamps
+      timestamps: stats.data.epoch.timestamps,
+      https: looksLikeHTTPS(urlFromConfig)
     }
 
     const stake = stakeHash(stats, urlFromConfig)

--- a/src/lib/debug.js
+++ b/src/lib/debug.js
@@ -70,6 +70,10 @@ export function findIncorrectHash (badNode, goodNode) {
   }
 }
 
+/**
+ * If a node is reported not to be grad A, debug tries to figure out what is not right
+ * about it so that anyone running vaguer can try and fix it.
+*/
 export function debug (nodes) {
   let gradeANode
 

--- a/src/lib/https-check.js
+++ b/src/lib/https-check.js
@@ -2,7 +2,7 @@ const query = `{
   epoch {
     id
   }
-`
+}`
 
 /**
  * Some nodes are defined in the configuration with HTTPS urls. Some with HTTP urls.
@@ -10,8 +10,17 @@ const query = `{
  */
 export async function httpsCheck (nodes) {
   // data.https has already been set in check.js, using looksLikeHTTPS
-  await nodes.filter(n => n.data.https === false).map(async n => {
-    const forceHTTPS = n.host.replace('http', 'https')
+  await Promise.all(nodes.filter(n => {
+    if (!n || !n.https || n.data.error) {
+      return false
+    }
+    return n.data.startup.https === false
+  }).map(async n => {
+    const forceHTTPS = forceToHTTPS(n.host)
+
+    if (process.env.DEBUG) {
+      console.debug(`HTTPS check for TOML entry: ${n.host}`)
+    }
 
     // Fetch the very basic GQL query above
     try {
@@ -27,28 +36,54 @@ export async function httpsCheck (nodes) {
         }
       })
 
-      const e = res.json()
+      const e = await res.json()
       if (e && e.data.epoch) {
-        n.data.https = true
+        n.https = true
+        if (process.env.DEBUG) {
+          console.debug(`HTTPS check: ${n.host} forced to ${forceHTTPS} works OK: toml should be updated`)
+        }
       } else {
         // Shouldn't be required, but let's play safe
-        n.data.https = false
+        n.https = false
+        if (process.env.DEBUG) {
+          console.debug(`HTTPS check: ${n.host} does not serve over https`)
+        }
       }
     } catch (e) {
       // Shouldn't be required, but let's play safe
-      n.data.https = false
+      n.https = false
+      if (process.env.DEBUG) {
+        console.debug(`HTTPS check: ${n.host} could not be fetched`)
+      }
     }
-  })
+  }))
 
   return nodes
 }
 
 /**
- * Uses a very basic string check to see if a node looks like it's
- * serving on HTTPS
- *
+ * Check if a URL is https
  * @return boolean true if URL looks https-y
  */
 export function looksLikeHTTPS (url) {
-  return url && url.substring(0, 5) === 'https'
+  try {
+    const u = new URL(url)
+    return u && u.protocol === 'https:'
+  } catch (e) {
+    return false
+  }
+}
+
+/**
+ * Force a url to https
+ * @return string
+ */
+export function forceToHTTPS (url) {
+  try {
+    const u = new URL(url)
+    u.protocol = 'https:'
+    return u.toString()
+  } catch (e) {
+    return url
+  }
 }

--- a/src/lib/https-check.js
+++ b/src/lib/https-check.js
@@ -1,0 +1,54 @@
+const query = `{
+  epoch {
+    id
+  }
+`
+
+/**
+ * Some nodes are defined in the configuration with HTTPS urls. Some with HTTP urls.
+ * This check is for the HTTP urls, to see if they have a corresponding HTTPS endpoint
+ */
+export async function httpsCheck (nodes) {
+  // data.https has already been set in check.js, using looksLikeHTTPS
+  await nodes.filter(n => n.data.https === false).map(async n => {
+    const forceHTTPS = n.host.replace('http', 'https')
+
+    // Fetch the very basic GQL query above
+    try {
+      const res = await fetch(forceHTTPS, {
+        method: 'POST',
+        body: JSON.stringify({
+          variables: null,
+          query
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: forceHTTPS
+        }
+      })
+
+      const e = res.json()
+      if (e && e.data.epoch) {
+        n.data.https = true
+      } else {
+        // Shouldn't be required, but let's play safe
+        n.data.https = false
+      }
+    } catch (e) {
+      // Shouldn't be required, but let's play safe
+      n.data.https = false
+    }
+  })
+
+  return nodes
+}
+
+/**
+ * Uses a very basic string check to see if a node looks like it's
+ * serving on HTTPS
+ *
+ * @return boolean true if URL looks https-y
+ */
+export function looksLikeHTTPS (url) {
+  return url && url.substring(0, 5) === 'https'
+}

--- a/src/lib/output.js
+++ b/src/lib/output.js
@@ -22,7 +22,8 @@ export async function output (nodes) {
       marketsHash: node.marketsHash ? node.marketsHash.substr(-6) : '-',
       assetsHash: node.assetsHash ? node.assetsHash.substr(-6) : '-',
       governanceHash: node.governanceHash ? node.governanceHash.substr(-6) : '-',
-      hashHash: node.hashHash ? node.hashHash.substr(-6) : '-'
+      hashHash: node.hashHash ? node.hashHash.substr(-6) : '-',
+      https: node.hasHttps ? '✅' : '❌'
     }
     output[grade] = node[grade]
     return output

--- a/src/lib/output.js
+++ b/src/lib/output.js
@@ -23,7 +23,7 @@ export async function output (nodes) {
       assetsHash: node.assetsHash ? node.assetsHash.substr(-6) : '-',
       governanceHash: node.governanceHash ? node.governanceHash.substr(-6) : '-',
       hashHash: node.hashHash ? node.hashHash.substr(-6) : '-',
-      https: node.hasHttps ? '✅' : '❌'
+      https: node.https ? '✓' : '-'
     }
     output[grade] = node[grade]
     return output


### PR DESCRIPTION
Adds an HTTPS check that checks only nodes that look like they're HTTP only to see 
if they also return a result on HTTPS

- feat: check https for nodes that are not explicitly https
- finish https check for http nodes
- feat: add `SUPPORT_053` env var that uses an older query


