### PR TITLE
Check candles in marketHash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ assets
 .dockerignore
 .npmignore
 .gitignore
-
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "^5.3.0",
         "console-table-printer": "^2.12.0",
+        "date-fns": "^3.3.1",
         "diff": "^5.2.0",
         "fast-json-stable-stringify": "^2.1.0",
         "fast-sha256": "^1.3.0",
@@ -529,6 +530,15 @@
         "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.3.1.tgz",
+      "integrity": "sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "console-table-printer": "^2.12.0",
+    "date-fns": "^3.3.1",
     "diff": "^5.2.0",
     "fast-json-stable-stringify": "^2.1.0",
     "fast-sha256": "^1.3.0",

--- a/src/lib/check.js
+++ b/src/lib/check.js
@@ -1,8 +1,12 @@
 import { listHash, stakeHash, paramHash, prepareForHash, sortLists } from './hash.js'
 import { looksLikeHTTPS } from './https-check.js'
+import { subHours, formatISO } from 'date-fns'
 
 // Statistics to pull from the `statistics` property of the result and put on each node
 const statsWeCareAbout = ['blockHeight', 'totalPeers']
+const intervalHours = 1
+const candleCount = 24
+const timestamp = formatISO(subHours(new Date(), (candleCount * intervalHours) + 1))
 
 // This query runs against all nodes and is the basis for the data comparison
 const query = `{
@@ -110,7 +114,7 @@ const query = `{
           trigger
           markPrice
         }
-        candlesConnection(interval: INTERVAL_I1H, since: "2024-02-10T14:42:31+00:00", pagination: { last: 5 }) {
+        candlesConnection(interval: INTERVAL_I${intervalHours}H, since: "${timestamp}", pagination: { last: ${candleCount} }) {
           edges {
             node {
               notional

--- a/src/lib/check.js
+++ b/src/lib/check.js
@@ -5,7 +5,7 @@ import { subHours, formatISO } from 'date-fns'
 // Statistics to pull from the `statistics` property of the result and put on each node
 const statsWeCareAbout = ['blockHeight', 'totalPeers']
 const intervalHours = 1
-const candleCount = 24
+const candleCount = 36
 const timestamp = formatISO(subHours(new Date(), (candleCount * intervalHours) + 1))
 
 // This query runs against all nodes and is the basis for the data comparison

--- a/src/lib/debug.js
+++ b/src/lib/debug.js
@@ -41,7 +41,6 @@ export function hashMismatchOutput (hashName, badProperty, goodProperty) {
  * @param goodNode an object containing the responses from a known good node
  */
 export function findIncorrectHash (badNode, goodNode) {
-  console.dir(badNode)
   if (badNode.startupHash !== goodNode.startupHash) {
     hashMismatchOutput('Startup', badNode.data.startup, goodNode.data.startup)
   }


### PR DESCRIPTION
- **fix connections**
- **remove hardcoded candle origin date**
- **increase candle count**

Some nodes on some networks have empty candles for some date ranges. While the cause isn't known, the effect is that 
those nodes are unsuitable for console usage. To track this, candles are now requested on the marketsConnection part
of the query and included in the markets hash.

Nodes are now more likely to differ on marketHash, but this difference has an impact so it's worth tracking.

Currently the value defaults to 36 1 hour candles. This is a high enough value that it is meaningful, but low enough that
no nodes that are currently checked change status.
